### PR TITLE
Separate nav svg styling from asset svg styling

### DIFF
--- a/src/styles/base/general.scss
+++ b/src/styles/base/general.scss
@@ -20,7 +20,7 @@ button {
   cursor: pointer;
 }
 
-svg {
+.tab-bar svg, .sidebar svg, .actions-bar svg {
   fill: currentColor;
   pointer-events: none;
 }


### PR DESCRIPTION
Once merged and the dependency is bumped in `ember-svg-jar`, [this bug](https://github.com/ivanvotti/ember-svg-jar/issues/158) will be fixed.